### PR TITLE
Text Fallback for unavailable glyphs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -467,8 +467,7 @@
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-      "dev": true
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
     "http-errors": {
       "version": "1.6.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "compression": "^1.7.1",
     "express": "^4.15.3",
     "express-winston": "^2.4.0",
+    "he": "^1.1.1",
     "sharp": "^0.18.4",
     "text-to-svg": "3.1.0",
     "winston": "^2.3.1"

--- a/src/app.js
+++ b/src/app.js
@@ -18,7 +18,7 @@ const allGlyphsAvailable = initials => {
     return !initials.split('').some(char => font.charToGlyph(char).index === 0);
 };
 
-const pathSvg = (initials, color) => {
+const svgPath = (initials, color) => {
     const path = textToSVG.getPath(initials, {
         x: FONT_SIZE,
         y: FONT_SIZE,
@@ -27,30 +27,45 @@ const pathSvg = (initials, color) => {
         attributes: { fill: '#FFFFFF' },
     });
     return `<svg
-        xmlns="http://www.w3.org/2000/svg"
-        version="1.1"
-        viewBox="0 0 ${SIZE} ${SIZE}" width="${SIZE}" height="${SIZE}">
-            <rect
-                x="0"
-                y="0"
-                width="${SIZE}"
-                height="${SIZE}"
-                fill="${color || '#ffeeee'}"
-                stroke-width="0"
-            />
-            ${path}
-    </svg>`;
+    xmlns="http://www.w3.org/2000/svg"
+    version="1.1"
+    viewBox="0 0 ${SIZE} ${SIZE}" width="${SIZE}" height="${SIZE}">
+        <rect
+            x="0"
+            y="0"
+            width="${SIZE}"
+            height="${SIZE}"
+            fill="${color || '#ffeeee'}"
+            stroke-width="0"
+        />
+        ${path}
+</svg>`;
 };
 
-const textSvg = (initials, color) => {
-    return `<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 ${SIZE} ${SIZE}">
-        <rect x="0" y="0" width="${SIZE}" height="${SIZE}" fill="${color}" stroke-width="0" />
-        <text x="50%" y="68%" text-anchor="middle" fill="white" font-family="sans-serif" font-size="${SIZE /
-            2}">${he.escape(initials)}</text>
-    </svg>`;
-};
+const svgText = (initials, color) => `<text
+    x="50%"
+    y="68%"
+    text-anchor="middle"
+    fill="white"
+    font-family="sans-serif"
+    font-size="${SIZE / 2}">
+        ${he.escape(initials)}
+</text>`;
 
-const svg = (initials, color) => (allGlyphsAvailable(initials) ? pathSvg(initials, color) : textSvg(initials, color));
+const svg = (initials, color) => `<svg
+    xmlns="http://www.w3.org/2000/svg"
+    version="1.1"
+    viewBox="0 0 ${SIZE} ${SIZE}" width="${SIZE}" height="${SIZE}">
+        <rect
+            x="0"
+            y="0"
+            width="${SIZE}"
+            height="${SIZE}"
+            fill="${color || '#ffeeee'}"
+            stroke-width="0"
+        />
+        ${allGlyphsAvailable(initials) ? svgPath(initials, color) : svgText(initials, color)}
+</svg>`;
 
 const toSvg = (req, res) => {
     const { initials, index } = req.params;

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -41,13 +41,23 @@ describe('Avatar service', () => {
                     else done(new Error());
                 });
         });
-        it('should render a path element', done => {
+        it('should render a path element for available glyphs', done => {
             request(app)
                 .get(BASE_URL + '/12/PF.svg')
                 .expect(200)
                 .parse(binaryParser)
                 .end((err, res) => {
                     if (/<path(.|\n)*?\/>/.test(res.body.toString())) done();
+                    else done(new Error());
+                });
+        });
+        it('should render a text element for unavailable glyphs', done => {
+            request(app)
+                .get(BASE_URL + '/12/P%E6%A0%91.svg')
+                .expect(200)
+                .parse(binaryParser)
+                .end((err, res) => {
+                    if (/<text(.|\n)*?\>/.test(res.body.toString())) done();
                     else done(new Error());
                 });
         });


### PR DESCRIPTION
Fix for #1 

If one of the two characters can't be found inside our font, we simply return a `<text>` element instead of a `<path>`. This is not an optimal solution, since we don't have control over how the resulting svg will look, but for now the simplest solution. Also the png version might not work when deployed, since it will rely on system fonts on the server.

In the future we could look at [Noto](https://www.google.com/get/noto/), but unfortunately that's also [not available as a single font file](https://github.com/googlei18n/noto-fonts/issues/13). That means we'd have to iterate through several files and even merge two paths if we can't find both characters in a single font file.